### PR TITLE
feat: Add support for AdvancedChests in shops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+.idea/
+
+target/

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -29,7 +29,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.3.0-SNAPSHOT</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -126,6 +126,12 @@
       <groupId>net.citizensnpcs</groupId>
       <artifactId>citizensapi</artifactId>
       <version>2.0.29-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.DeadSilenceIV</groupId>
+      <artifactId>AdvancedChestsAPI</artifactId>
+      <version>2.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.3.0-SNAPSHOT</version>
+				<version>3.3.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -181,6 +181,14 @@
 			<groupId>net.citizensnpcs</groupId>
 			<artifactId>citizensapi</artifactId>
 			<version>2.0.29-SNAPSHOT</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- ADVANCED CHESTS API -->
+		<dependency>
+			<groupId>com.github.DeadSilenceIV</groupId>
+			<artifactId>AdvancedChestsAPI</artifactId>
+			<version>2.4</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -36,6 +36,8 @@ Options:
       disabledSubCommands: {}
   #Using Citizens NPCs as Shops. Otherwise Villagers
   useNPCs: true
+  #Using also AdvancedChests for shops. Only vanilla if not.
+  useAdvancedChests: false
   #Shows above the Shop NPC the Prefix and DisplayName of a Player, if false: Only the Name
   useDisplayName: false
   #If enabled, every command gets a Permission -> Default: rentit.shop.<subcommand> and rentit.shops / rentit.freeshops -> the same for hotelrooms

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,4 +4,4 @@ version: ${project.version}
 api-version: 1.16
 main: me.truemb.rentit.main.Main
 depend: [WorldEdit, Vault]
-softdepend: [WorldGuard, Citizens, PlaceholderAPI]
+softdepend: [WorldGuard, Citizens, PlaceholderAPI, AdvancedChests]

--- a/src/me/truemb/rentit/filemanager/ShopCacheFileManager.java
+++ b/src/me/truemb/rentit/filemanager/ShopCacheFileManager.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import me.truemb.rentit.utils.chests.SupportedChest;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -50,13 +51,13 @@ public class ShopCacheFileManager {
 	public void setShopBackup(UUID uuid, int id) {
 		
 		YamlConfiguration cfg = this.getConfig();
-		
-		List<Inventory> inventories = this.instance.getMethodes().getShopChestInventories(id);
+
+		List<SupportedChest> chests = this.instance.getChestsUtils().getShopChests(id);
 		
 		String basicPath = String.valueOf(id) + "." + uuid.toString();
 		
-		for(int i = 0; i < inventories.size(); i++) {
-			cfg.set(basicPath + "." + i, InventoryUtils.itemStackArrayToBase64(inventories.get(i).getContents()));
+		for(int i = 0; i < chests.size(); i++) {
+			cfg.set(basicPath + "." + i, InventoryUtils.itemStackArrayToBase64(chests.get(i).getAllItems().toArray(ItemStack[]::new)));
 		}
 		
 		RentTypeHandler rentHandler = instance.getMethodes().getTypeHandler(RentTypes.SHOP, id);
@@ -69,7 +70,7 @@ public class ShopCacheFileManager {
 					item = ShopItemManager.removeShopItem(this.instance, item);
 			}
 			
-			cfg.set(basicPath + "." + String.valueOf(inventories.size()), InventoryUtils.itemStackArrayToBase64(sellItems));
+			cfg.set(basicPath + "." + String.valueOf(chests.size()), InventoryUtils.itemStackArrayToBase64(sellItems));
 		}
 		
 		try {

--- a/src/me/truemb/rentit/listener/ShopListener.java
+++ b/src/me/truemb/rentit/listener/ShopListener.java
@@ -113,9 +113,9 @@ public class ShopListener implements Listener {
 				p.getInventory().addItem(copyItem); // GIVES BUYER THE ITEM
 				Bukkit.getPluginManager().callEvent(new ItemSellEvent(p, rentHandler, copyItem, price));
 
-				if (this.instance.getMethodes().checkChestsinArea(shopId, copyItem)) {
+				if (this.instance.getChestsUtils().checkChestsInArea(shopId, copyItem)) {
 					// LOOKS IN NEARBY CHESTS
-					this.instance.getMethodes().removeItemFromChestsInArea(shopId, copyItem);
+					this.instance.getChestsUtils().removeItemFromChestsInArea(shopId, copyItem);
 
 				} else {
 					// CHANGES THE SHOP INV
@@ -237,10 +237,10 @@ public class ShopListener implements Listener {
 
 				copyItem.setAmount(amount); // SETS HOW MUCH THE PLAYER SELLED
 
-				if (this.instance.getMethodes().checkForSpaceinArea(shopId, copyItem)) {
+				if (this.instance.getChestsUtils().checkForSpaceInArea(shopId, copyItem)) {
 
 					// LOOKS IN NEARBY CHESTS
-					this.instance.getMethodes().addItemToChestsInArea(shopId, copyItem);
+					this.instance.getChestsUtils().addItemToChestsInArea(shopId, copyItem);
 					this.instance.getMethodes().removeItemFromPlayer(p, copyItem);
 
 					this.instance.getEconomy().depositPlayer(p, price); // REMVOES THE MONEY FROM THE BUYER

--- a/src/me/truemb/rentit/main/Main.java
+++ b/src/me/truemb/rentit/main/Main.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import me.truemb.rentit.utils.chests.ChestsUtils;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -108,6 +109,7 @@ public class Main extends JavaPlugin {
 	private BackupManager backupMGR;
 	private ShopItemManager shopItemMGR;
 	private UtilMethodes shopMeth;
+	private ChestsUtils chestsUtils;
 	
 	//SOFTDEPEND
 	private WorldGuardUtils wgUtils;
@@ -161,7 +163,8 @@ public class Main extends JavaPlugin {
 				initHandlers();
 			}
 		}, 20);
-		
+
+		this.chestsUtils = new ChestsUtils(this);
 		this.backupMGR = new BackupManager(this);
 		this.shopItemMGR = new ShopItemManager();
 		this.npcFM = new NPCFileManager(this);
@@ -370,6 +373,7 @@ public class Main extends JavaPlugin {
 				
 				//START MANAGERS
 				shopMeth = new UtilMethodes(plugin);
+				chestsUtils = new ChestsUtils(plugin);
 				backupMGR = new BackupManager(plugin);
 				shopItemMGR = new ShopItemManager();
 				npcFM = new NPCFileManager(plugin);
@@ -658,6 +662,10 @@ public class Main extends JavaPlugin {
 	
 	public UtilMethodes getMethodes() {
 		return this.shopMeth;
+	}
+
+	public ChestsUtils getChestsUtils() {
+		return this.chestsUtils;
 	}
 	
 	public SignFileManager getSignFileManager() {

--- a/src/me/truemb/rentit/utils/UtilMethodes.java
+++ b/src/me/truemb/rentit/utils/UtilMethodes.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import me.truemb.rentit.utils.chests.ChestsUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -43,9 +44,11 @@ import net.md_5.bungee.api.chat.hover.content.Text;
 public class UtilMethodes {
 
 	private Main instance;
+	private ChestsUtils chestsUtils;
 
 	public UtilMethodes(Main plugin) {
 		this.instance = plugin;
+		this.chestsUtils = new ChestsUtils(plugin);
 	}
 
 	public boolean isTimeFormat(String feString) {
@@ -533,96 +536,22 @@ public class UtilMethodes {
 
 	// CHECK CHESTS FOR ITEM
 	public boolean checkChestsinArea(int shopId, ItemStack item) {
-
-		List<Inventory> chestInventories = this.getShopChestInventories(shopId);
-		int amount = item.getAmount();
-
-		for(Inventory inv : chestInventories) {
-			for (ItemStack items : inv.getContents()) {
-				if (items != null) {
-					if (items.isSimilar(item)) {
-						amount -= items.getAmount();
-						if (amount <= 0)
-							return true;
-					}
-				}
-			}
-		}
-		return false;
+		return chestsUtils.checkChestsInArea(shopId, item);
 	}
 	
 	// CHECK IF SPACES
 	public boolean checkForSpaceinArea(int shopId, ItemStack item) {
-
-		List<Inventory> chestInventories = this.getShopChestInventories(shopId);
-		int amount = item.getAmount();
-
-		for(Inventory inv : chestInventories) {
-			for (ItemStack items : inv.getContents()) {
-				if (items == null || items.getType() == Material.AIR) {
-					return true;
-				} else if (items.isSimilar(item)) {
-					if (amount > 64 - items.getAmount()) {
-						amount -= 64 - items.getAmount();
-					} else {
-						return true;
-					}
-				}
-			}
-		}
-		return false;
+		return chestsUtils.checkForSpaceInArea(shopId, item);
 	}
 
 	// REMOVES ITEMS FROM CHESTS
 	public void removeItemFromChestsInArea(int shopId, ItemStack item) {
-		
-		List<Inventory> chestInventories = this.getShopChestInventories(shopId);
-		int amount = item.getAmount();
-
-		for(Inventory inv : chestInventories) {
-			for (ItemStack items : inv.getContents()) {
-				if (items != null) {
-					if (items.isSimilar(item)) {
-						
-						if (amount >= items.getAmount()) {
-							amount -= items.getAmount();
-							items.setAmount(0);
-						} else {
-							items.setAmount(items.getAmount() - amount);
-							amount = 0;
-							return;
-						}
-					}
-				}
-			}
-		}
+		chestsUtils.removeItemFromChestsInArea(shopId, item);
 	}
 
-	// REMOVES ITEMS FROM CHESTS
+	// ADDS ITEMS FROM CHESTS
 	public void addItemToChestsInArea(int shopId, ItemStack item) {
-
-		List<Inventory> chestInventories = this.getShopChestInventories(shopId);
-		int amount = item.getAmount();
-
-		for(Inventory inv : chestInventories) {
-			for (int i = 0; i < inv.getSize(); i++) {
-				ItemStack items = inv.getItem(i);
-				if (items == null || items.getType() == Material.AIR) {
-					inv.setItem(i, item);
-					return;
-				} else if (items.isSimilar(item)) {
-					if (amount > 64 - items.getAmount()) {
-						items.setAmount(64);
-						amount -= 64 - items.getAmount();
-						inv.setItem(i, items);
-					} else {
-						items.setAmount(items.getAmount() + amount);
-						inv.setItem(i, items);
-						return;
-					}
-				}
-			}
-		}
+		chestsUtils.addItemToChestsInArea(shopId, item);
 	}
 
 	public void removeItemFromPlayer(Player p, ItemStack item) {

--- a/src/me/truemb/rentit/utils/UtilMethodes.java
+++ b/src/me/truemb/rentit/utils/UtilMethodes.java
@@ -511,6 +511,7 @@ public class UtilMethodes {
 	}
 
 	public List<Inventory> getShopChestInventories(int shopId) {
+		// TODO pending
 		World world = this.instance.getAreaFileManager().getWorldFromArea(RentTypes.SHOP, shopId);
 		BlockVector3 min = this.instance.getAreaFileManager().getMinBlockpoint(RentTypes.SHOP, shopId);
 		BlockVector3 max = this.instance.getAreaFileManager().getMaxBlockpoint(RentTypes.SHOP, shopId);

--- a/src/me/truemb/rentit/utils/UtilMethodes.java
+++ b/src/me/truemb/rentit/utils/UtilMethodes.java
@@ -510,51 +510,6 @@ public class UtilMethodes {
 		p.sendMessage(this.instance.getMessage(path + ".footer"));
 	}
 
-	public List<Inventory> getShopChestInventories(int shopId) {
-		// TODO pending
-		World world = this.instance.getAreaFileManager().getWorldFromArea(RentTypes.SHOP, shopId);
-		BlockVector3 min = this.instance.getAreaFileManager().getMinBlockpoint(RentTypes.SHOP, shopId);
-		BlockVector3 max = this.instance.getAreaFileManager().getMaxBlockpoint(RentTypes.SHOP, shopId);
-		
-		List<Inventory> chestInventories = new ArrayList<>();
-
-		for (int minX = min.getBlockX(); minX <= max.getBlockX(); minX++) {
-			for (int minZ = min.getBlockZ(); minZ <= max.getBlockZ(); minZ++) {
-				for (int minY = min.getBlockY(); minY <= max.getBlockY(); minY++) {
-					Block b = world.getBlockAt(minX, minY, minZ);
-					if (b != null && b.getType() == Material.CHEST) {
-						Chest chest = (Chest) b.getState();
-						Inventory chestInv = chest.getBlockInventory();
-						
-						chestInventories.add(chestInv);
-					}
-				}
-			}
-		}
-		
-		return chestInventories;
-	}
-
-	// CHECK CHESTS FOR ITEM
-	public boolean checkChestsinArea(int shopId, ItemStack item) {
-		return chestsUtils.checkChestsInArea(shopId, item);
-	}
-	
-	// CHECK IF SPACES
-	public boolean checkForSpaceinArea(int shopId, ItemStack item) {
-		return chestsUtils.checkForSpaceInArea(shopId, item);
-	}
-
-	// REMOVES ITEMS FROM CHESTS
-	public void removeItemFromChestsInArea(int shopId, ItemStack item) {
-		chestsUtils.removeItemFromChestsInArea(shopId, item);
-	}
-
-	// ADDS ITEMS FROM CHESTS
-	public void addItemToChestsInArea(int shopId, ItemStack item) {
-		chestsUtils.addItemToChestsInArea(shopId, item);
-	}
-
 	public void removeItemFromPlayer(Player p, ItemStack item) {
 
 		int amount = item.getAmount();

--- a/src/me/truemb/rentit/utils/chests/AdvancedChestsChest.java
+++ b/src/me/truemb/rentit/utils/chests/AdvancedChestsChest.java
@@ -38,12 +38,12 @@ public class AdvancedChestsChest extends SupportedChest {
     }
 
     @Override
-    public boolean hasEmptySlots() {
-        return this.chest.getSlotsLeft() > 0;
+    public List<ItemStack> getAllItems() {
+        return this.chest.getAllItems();
     }
 
     @Override
-    protected List<ItemStack> getAllItems() {
-        return this.chest.getAllItems();
+    public boolean hasEmptySlots() {
+        return this.chest.getSlotsLeft() > 0;
     }
 }

--- a/src/me/truemb/rentit/utils/chests/AdvancedChestsChest.java
+++ b/src/me/truemb/rentit/utils/chests/AdvancedChestsChest.java
@@ -1,0 +1,49 @@
+package me.truemb.rentit.utils.chests;
+
+import org.bukkit.Location;
+import org.bukkit.inventory.ItemStack;
+import us.lynuxcraft.deadsilenceiv.advancedchests.AdvancedChestsAPI;
+import us.lynuxcraft.deadsilenceiv.advancedchests.chest.AdvancedChest;
+
+import java.util.List;
+import java.util.Optional;
+
+public class AdvancedChestsChest extends SupportedChest {
+    private final AdvancedChest chest;
+
+    public AdvancedChestsChest(AdvancedChest chest) {
+        this.chest = chest;
+    }
+
+    public static Optional<SupportedChest> getChestInLocation(Location location) {
+        AdvancedChest chest = AdvancedChestsAPI.getChestManager().getAdvancedChest(location);
+
+        if (chest != null) {
+            return Optional.of(new AdvancedChestsChest(chest));
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public void add(ItemStack item) {
+        AdvancedChestsAPI.addItemToChest(this.chest, item);
+    }
+
+    @Override
+    public void add(ItemStack item, int amount) {
+        ItemStack clone = item.clone();
+        clone.setAmount(amount);
+        this.add(clone);
+    }
+
+    @Override
+    public boolean hasEmptySlots() {
+        return this.chest.getSlotsLeft() > 0;
+    }
+
+    @Override
+    protected List<ItemStack> getAllItems() {
+        return this.chest.getAllItems();
+    }
+}

--- a/src/me/truemb/rentit/utils/chests/ChestsUtils.java
+++ b/src/me/truemb/rentit/utils/chests/ChestsUtils.java
@@ -1,0 +1,165 @@
+package me.truemb.rentit.utils.chests;
+
+import com.sk89q.worldedit.math.BlockVector3;
+import me.truemb.rentit.enums.RentTypes;
+import me.truemb.rentit.main.Main;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class ChestsUtils {
+    private Main instance;
+    private static Main _plugin;
+
+    public ChestsUtils(Main plugin) {
+        this.instance = plugin;
+        _plugin = plugin;
+    }
+
+    public static Main getPlugin() {
+        return _plugin;
+    }
+
+    /**
+     * Returns a list of wrappers manipulate any chest supported and enabled.
+     * @param shopId The id of the shop to get all the chests from.
+     */
+    public List<SupportedChest> getShopChests(int shopId) {
+        World world = this.instance.getAreaFileManager().getWorldFromArea(RentTypes.SHOP, shopId);
+        BlockVector3 min = this.instance.getAreaFileManager().getMinBlockpoint(RentTypes.SHOP, shopId);
+        BlockVector3 max = this.instance.getAreaFileManager().getMaxBlockpoint(RentTypes.SHOP, shopId);
+
+        List<SupportedChest> chests = new ArrayList<>();
+
+        for (int minX = min.getBlockX(); minX <= max.getBlockX(); minX++) {
+            for (int minZ = min.getBlockZ(); minZ <= max.getBlockZ(); minZ++) {
+                for (int minY = min.getBlockY(); minY <= max.getBlockY(); minY++) {
+                    Location location = new Location(world, minX, minY, minZ);
+
+                    this.getChestInLocation(location).ifPresent(chests::add);
+                }
+            }
+        }
+
+        return chests;
+    }
+
+    // CHECK CHESTS FOR ITEM
+    /**
+     * For each of the supported chest types, checks if there's stock of a given item. If the amount is greater than 1,
+     * this method could pull up part of the amount from one chest type and the other part from a different type.
+     */
+    public boolean checkChestsInArea(int shopId, ItemStack item) {
+        List<SupportedChest> chests = this.getShopChests(shopId);
+        int amount = item.getAmount();
+
+        for (SupportedChest chest : chests) {
+            amount -= chest.count(item);
+
+            if (amount <= 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // CHECK IF SPACES
+    /**
+     * For each of the supported chest types, checks if there is enough space in any of them
+     * to fit the given item.
+     */
+    public boolean checkForSpaceInArea(int shopId, ItemStack item) {
+        List<SupportedChest> chests = this.getShopChests(shopId);
+        int amount = item.getAmount();
+
+        for (SupportedChest chest : chests) {
+            if (chest.hasEmptySlots()) {
+                return true;
+            }
+
+            amount -= chest.countAvailable(item);
+
+            if (amount <= 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    // REMOVES ITEMS FROM CHESTS
+    /**
+     * For each of the supported chest types, removes the given item. If the amount is greater than 1,
+     * this method could remove part of the amount from one chest type and the other part from a different type.
+     */
+    public void removeItemFromChestsInArea(int shopId, ItemStack item) {
+        List<SupportedChest> chests = this.getShopChests(shopId);
+        int amount = item.getAmount();
+
+        for (SupportedChest chest : chests) {
+            for (ItemStack itemStack : chest.getAllSimilarItems(item)) {
+                if (amount >= itemStack.getAmount()) {
+                    amount -= itemStack.getAmount();
+                    itemStack.setAmount(0);
+                } else {
+                    itemStack.setAmount(itemStack.getAmount() - amount);
+                    return;
+                }
+            }
+        }
+    }
+
+    // ADDS ITEMS FROM CHESTS
+    /**
+     * For each of the supported chest types, adds the given item. If the amount is greater than 1,
+     * this method could add part of the amount to one chest type and the other part to a different type.
+     */
+    public void addItemToChestsInArea(int shopId, ItemStack item) {
+        List<SupportedChest> chests = this.getShopChests(shopId);
+        int amount = item.getAmount();
+
+        for (SupportedChest chest : chests) {
+            if (chest.hasEmptySlots()) {
+                chest.add(item);
+                return;
+            }
+
+            int space = chest.countAvailable(item);
+            if (amount > space) {
+                chest.add(item, amount - space);
+                amount -= space;
+            } else {
+                chest.add(item, amount);
+                return;
+            }
+        }
+    }
+
+    /**
+     * Gets the supported chest for a given location, if any.
+     */
+    private Optional<SupportedChest> getChestInLocation(Location location) {
+        if (this.instance.manageFile().getBoolean("Options.useAdvancedChests")
+                && Bukkit.getServer().getPluginManager().isPluginEnabled("AdvancedChests")
+        ) {
+            /**
+             * Advanced chests are implemented as a CHEST item.
+             * If we don't early cut the lookup, we end up loading 1 adv chest + 1 vanilla chest
+             * for the same location.
+             */
+            Optional<SupportedChest> adv = AdvancedChestsChest.getChestInLocation(location);
+            if (adv.isPresent()) {
+                return adv;
+            }
+        }
+
+        return VanillaChest.getChestInLocation(location);
+    }
+}

--- a/src/me/truemb/rentit/utils/chests/ChestsUtils.java
+++ b/src/me/truemb/rentit/utils/chests/ChestsUtils.java
@@ -14,15 +14,9 @@ import java.util.Optional;
 
 public class ChestsUtils {
     private Main instance;
-    private static Main _plugin;
 
     public ChestsUtils(Main plugin) {
         this.instance = plugin;
-        _plugin = plugin;
-    }
-
-    public static Main getPlugin() {
-        return _plugin;
     }
 
     /**

--- a/src/me/truemb/rentit/utils/chests/SupportedChest.java
+++ b/src/me/truemb/rentit/utils/chests/SupportedChest.java
@@ -1,0 +1,54 @@
+package me.truemb.rentit.utils.chests;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public abstract class SupportedChest {
+
+    /**
+     * Adds the item to the chest
+     */
+    public abstract void add(ItemStack item);
+
+    /**
+     * Adds the requested amount to any similar item in the chest
+     */
+    public abstract void add(ItemStack item, int amount);
+
+    /**
+     * Counts how many of a given item there is in the chest
+     */
+    public int count(ItemStack item) {
+        return this.getAllSimilarItems(item).stream().mapToInt(ItemStack::getAmount).sum();
+    }
+
+    /**
+     * Counts how many available space for a given item there is by completing the stacks in the chest
+     */
+    public int countAvailable(ItemStack item) {
+        return this.getAllSimilarItems(item).stream().mapToInt(i -> i.getMaxStackSize() - i.getAmount()).sum();
+    }
+
+    /**
+     * Checks if there are any empty spaces in the items collection
+     */
+    public boolean hasEmptySlots() {
+        return getAllItems().stream().anyMatch(this::isEmptySlot);
+    }
+
+    /**
+     * Returns a subset of the chest's items which are similar to the given item.
+     */
+    public List<ItemStack> getAllSimilarItems(ItemStack item) {
+        return this.getAllItems().stream().filter(i -> item.isSimilar(i)).collect(Collectors.toList());
+    }
+
+    protected abstract List<ItemStack> getAllItems();
+
+    protected boolean isEmptySlot(ItemStack item) {
+        return item == null || item.getType() == Material.AIR;
+    }
+}

--- a/src/me/truemb/rentit/utils/chests/SupportedChest.java
+++ b/src/me/truemb/rentit/utils/chests/SupportedChest.java
@@ -18,6 +18,8 @@ public abstract class SupportedChest {
      */
     public abstract void add(ItemStack item, int amount);
 
+    public abstract List<ItemStack> getAllItems();
+
     /**
      * Counts how many of a given item there is in the chest
      */
@@ -45,8 +47,6 @@ public abstract class SupportedChest {
     public List<ItemStack> getAllSimilarItems(ItemStack item) {
         return this.getAllItems().stream().filter(i -> item.isSimilar(i)).collect(Collectors.toList());
     }
-
-    protected abstract List<ItemStack> getAllItems();
 
     protected boolean isEmptySlot(ItemStack item) {
         return item == null || item.getType() == Material.AIR;

--- a/src/me/truemb/rentit/utils/chests/VanillaChest.java
+++ b/src/me/truemb/rentit/utils/chests/VanillaChest.java
@@ -1,0 +1,57 @@
+package me.truemb.rentit.utils.chests;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.Chest;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public class VanillaChest extends SupportedChest {
+    private final Inventory inventory;
+
+    public VanillaChest(Inventory inventory) {
+        this.inventory = inventory;
+    }
+
+    public static Optional<SupportedChest> getChestInLocation(Location location) {
+        Block b = location.getBlock();
+        if (b != null && b.getType() == Material.CHEST) {
+            Chest chest = (Chest) b.getState();
+            Inventory chestInv = chest.getBlockInventory();
+
+            return Optional.of(new VanillaChest(chestInv));
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public void add(ItemStack item) {
+        this.inventory.addItem(item);
+    }
+
+    @Override
+    public void add(ItemStack item, int amount) {
+        int remaining = amount;
+
+        for (ItemStack i : this.getAllSimilarItems(item)) {
+            int available = i.getMaxStackSize() - i.getAmount();
+            i.setAmount(available > remaining ? i.getAmount() + remaining : i.getMaxStackSize());
+            remaining -= available;
+
+            if (remaining <= 0) {
+                return;
+            }
+        }
+    }
+
+    @Override
+    protected List<ItemStack> getAllItems() {
+        return Arrays.stream(this.inventory.getContents()).toList();
+    }
+}

--- a/src/me/truemb/rentit/utils/chests/VanillaChest.java
+++ b/src/me/truemb/rentit/utils/chests/VanillaChest.java
@@ -51,7 +51,7 @@ public class VanillaChest extends SupportedChest {
     }
 
     @Override
-    protected List<ItemStack> getAllItems() {
+    public List<ItemStack> getAllItems() {
         return Arrays.stream(this.inventory.getContents()).toList();
     }
 }


### PR DESCRIPTION
# Feature
Add support for [AdvancedChests](https://www.spigotmc.org/resources/%E2%AD%90advancedchests%E2%AD%90-unlimited-sizes-holograms-%E2%9C%A8upgrades-%E2%9C%85sells-%E2%9A%A1sorter-%E2%98%84%EF%B8%8F-compressor.79061/) plugin inside shops on top of regular vanilla chests for extra storage.
- AdvancedChests plugin added as `softdepend`
- New configuration created `useAdvancedChests` to enable them, initially set to false