### PR TITLE
fix: Safely remove chests when resetting area

### DIFF
--- a/src/me/truemb/rentit/commands/ShopCOMMAND.java
+++ b/src/me/truemb/rentit/commands/ShopCOMMAND.java
@@ -1947,6 +1947,8 @@ public class ShopCOMMAND extends BukkitCommand {
 
 		if(ownerUUID != null)
 			this.instance.getShopCacheFileManager().setShopBackup(ownerUUID, shopId);
+
+		this.instance.getChestsUtils().getShopChests(shopId).stream().forEach(chest -> chest.remove());
 			
 		BlockVector3 min = this.instance.getAreaFileManager().getMinBlockpoint(this.type, shopId);
 		BlockVector3 max = this.instance.getAreaFileManager().getMaxBlockpoint(this.type, shopId);

--- a/src/me/truemb/rentit/utils/chests/AdvancedChestsChest.java
+++ b/src/me/truemb/rentit/utils/chests/AdvancedChestsChest.java
@@ -46,4 +46,9 @@ public class AdvancedChestsChest extends SupportedChest {
     public boolean hasEmptySlots() {
         return this.chest.getSlotsLeft() > 0;
     }
+
+    @Override
+    public void remove() {
+        this.chest.remove(null, false);
+    }
 }

--- a/src/me/truemb/rentit/utils/chests/SupportedChest.java
+++ b/src/me/truemb/rentit/utils/chests/SupportedChest.java
@@ -48,6 +48,11 @@ public abstract class SupportedChest {
         return this.getAllItems().stream().filter(i -> item.isSimilar(i)).collect(Collectors.toList());
     }
 
+    /**
+     * Safely removes the chest from the area
+     */
+    public void remove() {}
+
     protected boolean isEmptySlot(ItemStack item) {
         return item == null || item.getType() == Material.AIR;
     }


### PR DESCRIPTION
By calling Advanced Chests to remove before resetting the World Guard region, the sync error is gone: https://pastebin.com/KAKYESrL.

I've noticed that if we have Advanced Chests as part of the region when set `/shop setArea`, those chests are not considered at the moment of renting it. I will try to work on that to unleash the full potential of this integration, but in the meantime this fix will avoid errors.